### PR TITLE
[refactor] Update border radius styles to use rem units

### DIFF
--- a/src/components/border/borderRadius.ts
+++ b/src/components/border/borderRadius.ts
@@ -1,27 +1,32 @@
-import {StyleSheet, Dimensions} from "react-native";
-
-const width = Dimensions.get("screen").width <= 545 ? Dimensions.get("screen").width : Dimensions.get("screen").width * 0.8;
+import {StyleSheet} from "react-native";
+import {rem} from "../typography/config"
 
 export const borderRadius = StyleSheet.create({
     br0: {
-        borderRadius: 0,
+        borderRadius: 0, // Tailwind: rounded-none
     },
     br1: {
-        borderRadius: width * 0.01,
+        borderRadius: rem(0.125), // Tailwind: rounded-sm (2px)
     },
     br2: {
-        borderRadius: width * 0.02,
+        borderRadius: rem(0.25), // Tailwind: rounded (4px)
     },
     br3: {
-        borderRadius: width * 0.03,
+        borderRadius: rem(0.375), // Tailwind: rounded-md (6px)
     },
     br4: {
-        borderRadius: width * 0.04,
+        borderRadius: rem(0.5), // Tailwind: rounded-lg (8px)
     },
     br5: {
-        borderRadius: width * 0.05,
+        borderRadius: rem(0.75), // Tailwind: rounded-xl (12px)
+    },
+    br6: {
+        borderRadius: rem(1), // Tailwind: rounded-2xl (16px)
+    },
+    br7: {
+        borderRadius: rem(1.5), // Tailwind: rounded-3xl (24px)
     },
     circle: {
-        borderRadius: width,
+        borderRadius: 9999, // Tailwind: rounded-full
     },
 });


### PR DESCRIPTION
## Changes

- Replaced width-based border radius calculations with rem-based values for consistency
- Added new border radius styles for larger radii (br6, br7)
- Maintained existing styles for smaller radii and circle
- Updated circle border radius to use 9999 for better cross-platform compatibility

## Technical Details

- Removed dependency on `Dimensions` API for width calculations
- Imported `rem` function from typography config for consistent spacing
- Added Tailwind CSS equivalent comments for better documentation
- Enhanced border radius scale with additional options (br6, br7)

## Benefits

- More consistent border radius values across different screen sizes
- Better maintainability with rem-based calculations
- Extended border radius options for design flexibility
- Improved cross-platform compatibility